### PR TITLE
Add launcher oauth secret and custom resource reconciler

### DIFF
--- a/deploy/crds/installation.crd.yaml
+++ b/deploy/crds/installation.crd.yaml
@@ -45,8 +45,6 @@ spec:
               type: string
           required:
             - type
-            - githubOauthClientId
-            - githubOauthClientSecret
         status:
           type: object
   version: v1alpha1

--- a/pkg/controller/installation/products/reconciler.go
+++ b/pkg/controller/installation/products/reconciler.go
@@ -11,9 +11,9 @@ import (
 	"github.com/integr8ly/integreatly-operator/pkg/controller/installation/products/fuse"
 	"github.com/integr8ly/integreatly-operator/pkg/controller/installation/products/launcher"
 	"github.com/integr8ly/integreatly-operator/pkg/controller/installation/products/rhsso"
+	appsv1Client "github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -34,7 +34,12 @@ func NewReconciler(product v1alpha1.ProductName, client client.Client, rc *rest.
 	case v1alpha1.ProductFuse:
 		reconciler, err = fuse.NewReconciler(coreClient, configManager, instance, mpm)
 	case v1alpha1.ProductLauncher:
-		reconciler, err = launcher.NewReconciler(coreClient, configManager, instance, mpm)
+		appsv1, err := appsv1Client.NewForConfig(rc)
+		if err != nil {
+			return nil, err
+		}
+
+		reconciler, err = launcher.NewReconciler(coreClient, appsv1, configManager, instance, mpm)
 	default:
 		err = errors.New("unknown products: " + string(product))
 		reconciler = &NoOp{}

--- a/pkg/controller/installation/types.go
+++ b/pkg/controller/installation/types.go
@@ -42,8 +42,7 @@ func newWorkshopType() *Type {
 		products: []v1alpha1.ProductName{v1alpha1.ProductRHSSO, v1alpha1.ProductLauncher, v1alpha1.ProductAMQStreams},
 		productOrder: [][]v1alpha1.ProductName{
 			{v1alpha1.ProductRHSSO},
-			{v1alpha1.ProductFuse, v1alpha1.ProductCodeReadyWorkspaces, v1alpha1.ProductAMQStreams},
-			{v1alpha1.ProductLauncher, v1alpha1.ProductCodeReadyWorkspaces, v1alpha1.ProductLauncher, v1alpha1.ProductAMQStreams},
+			{v1alpha1.ProductLauncher, v1alpha1.ProductFuse, v1alpha1.ProductCodeReadyWorkspaces, v1alpha1.ProductAMQStreams},
 		},
 	}
 }
@@ -53,8 +52,7 @@ func newManagedType() *Type {
 		products: []v1alpha1.ProductName{v1alpha1.ProductRHSSO},
 		productOrder: [][]v1alpha1.ProductName{
 			{v1alpha1.ProductRHSSO},
-			{v1alpha1.ProductCodeReadyWorkspaces, v1alpha1.ProductFuse},
-			{v1alpha1.ProductLauncher, v1alpha1.ProductCodeReadyWorkspaces},
+			{v1alpha1.ProductLauncher, v1alpha1.ProductCodeReadyWorkspaces, v1alpha1.ProductFuse},
 		},
 	}
 }


### PR DESCRIPTION
## What
- [x] Remove the `githubOauthClientId` and `githubOauthClientSecret` as a required param in the Installation CRD. This will instead be set with default placeholder values during the Github OAuth secret reconciliation. 
- [x] Implement Github OAuth secret reconcile
    - This creates the secret `launcher-oauth-github` in the Launcher namespace
    - If this secret already exists and there are new values are set to the `githubOauthClientId` and `githubOauthClientSecret` in the Installation custom resource, this reconcile phase should update it with the new values.
- [x] Implement Launcher custom resource reconcile
    - This should create the launcher custom resource in the Launcher namespace
    - It should also check for the pod status to ensure that the Launcher deployment is ready (There is no status in the Launcher custom resource, therefore we have no way of telling the status of the installation from it.)